### PR TITLE
perf: Shortcircuit hotkey validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ dist
 *.crx
 *.pem
 *.zip
+.vscode

--- a/src/content-scripts/hotkeys.ts
+++ b/src/content-scripts/hotkeys.ts
@@ -164,6 +164,12 @@ const runHotKey = (keyValues: { key: string; metaKey: boolean; ctrlKey: boolean;
 
 
 export const handleHotKeys = (event: KeyboardEvent) => {
+  if (!event.getModifierState('Control') && !event.getModifierState('Meta')) {
+    // If a modifier is not selected, we can short-circuit this.
+    log('No Modifier selected. Early return.');
+    return;
+  }
+
   // To override chrome hotkeys
   const { metaKey, ctrlKey, key, shiftKey } = event;
 


### PR DESCRIPTION
https://twitter.com/buildsghost/status/1261441775463358465

Uses `event.getModifierState` to prevent the full validation of hotkeys on every key press.