### PR TITLE
bugfix: support new css variables

### DIFF
--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -36,6 +36,9 @@ ThemeStyles.set(ThemeType.RefinedDark, `
   --button-primary-background: #434343;
   --button-primary-background-hover: #434343;
   --button-primary: #cbd4d9;
+  --bubble-meta-icon: #eee;
+  --chatlist-icon: #eee;
+  --bubble-meta: #eee;
   --button-secondary: #cbd4d9;
   --button-secondary-hover: #cbd4d9;
   --button-secondary-background-hover: #434343;
@@ -49,6 +52,7 @@ ThemeStyles.set(ThemeType.RefinedDark, `
   --intro-background: #151515;
   --background-default: rgb(36, 36, 36);
   --panel-background-lighter: rgb(36, 36, 36);
+  --panel-header-background: rgb(36, 36, 36);
   --panel-background: rgb(36, 36, 36);
   --background-default-hover: #434343;
   --primary-strong: #eee;


### PR DESCRIPTION
Looks like Whatsapp web has introduced some new CSS variables.

This PR adds support for those variables.

### Before

![image](https://user-images.githubusercontent.com/6417910/83883236-d924fb80-a760-11ea-9174-40cb7995c207.png)

![image](https://user-images.githubusercontent.com/6417910/83883267-e641ea80-a760-11ea-93f8-3badf8a39149.png)

![image](https://user-images.githubusercontent.com/6417910/83883293-ef32bc00-a760-11ea-8791-6b7abe5ac87d.png)

### After

![image](https://user-images.githubusercontent.com/6417910/83883395-0a9dc700-a761-11ea-800d-6e98c519d1c0.png)

![image](https://user-images.githubusercontent.com/6417910/83883419-14bfc580-a761-11ea-8be9-82126996ab53.png)

![image](https://user-images.githubusercontent.com/6417910/83883449-1d180080-a761-11ea-8203-4b9ac8e6c387.png)