### PR TITLE
feat: cycle through themes via switcher [WIP]

### DIFF
--- a/src/content-scripts/index.ts
+++ b/src/content-scripts/index.ts
@@ -1,30 +1,7 @@
 // this file runs at "document_idle" (see manifest)
 import { handleHotKeys } from './hotkeys';
-import { toggleTheme, setInitialTheme } from '../theme';
+import { setupThemes } from '../theme';
 
-const THEME_ICON = `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path fill="currentColor" d="M22.6 11.29L20 8.69V5c0-.55-.45-1-1-1h-3.69l-2.6-2.6c-.39-.39-1.02-.39-1.41 0L8.69 4H5c-.55 0-1 .45-1 1v3.69l-2.6 2.6c-.39.39-.39 1.02 0 1.41L4 15.3V19c0 .55.45 1 1 1h3.69l2.6 2.6c.39.39 1.02.39 1.41 0l2.6-2.6H19c.55 0 1-.45 1-1v-3.69l2.6-2.6c.39-.39.39-1.03 0-1.42zm-4.68 1.69c-.34 2.12-1.85 3.94-3.88 4.66-1.21.43-2.41.45-3.5.18-.41-.1-.48-.65-.13-.9C11.98 15.84 13 14.04 13 12s-1.02-3.84-2.58-4.92c-.35-.24-.29-.79.13-.9 1.09-.27 2.29-.25 3.5.18 2.02.72 3.54 2.54 3.88 4.66.05.33.07.66.07.98-.01.32-.03.65-.08.98z"/></svg>`;
 
 document.addEventListener('keydown', handleHotKeys);
-setInitialTheme();
-
-const poller = setInterval(() => {
-  const controlList = document.getElementById('side') as HTMLDivElement;
-
-  if (controlList) {
-    clearInterval(poller);
-
-    const themeBtn = document.createElement('span');
-    themeBtn.setAttribute('role', 'button');
-    themeBtn.innerHTML = THEME_ICON;
-    themeBtn.style.color = 'var(--icon)';
-    themeBtn.style.marginLeft = '12px';
-    themeBtn.addEventListener('click', () => {
-      toggleTheme();
-    });
-
-    controlList.children[0].appendChild(themeBtn);
-  }
-}, 500);
-
-// override default dark mode with extension's
-document.body.classList.remove('dark');
+setupThemes();

--- a/src/content-scripts/selectors.ts
+++ b/src/content-scripts/selectors.ts
@@ -4,3 +4,11 @@ export const getCloseNewChatSidebarButton = () =>
   document.querySelector(`button > [data-testid='back']`) as HTMLSpanElement;
 
 export const getSearchButton = () => document.querySelector(`[data-testid='search-alt']`) as HTMLSpanElement;
+
+export const getSidebarControls = () => document.getElementById(`side`) as HTMLDivElement;
+
+export const getSidebarControlsSettingsMenuButton = (controls?: HTMLDivElement) => {
+  const sidebarControls = controls || getSidebarControls();
+
+  return sidebarControls.querySelector(`div[title="Menu"]`) as HTMLDivElement;
+};

--- a/src/content-scripts/utils.ts
+++ b/src/content-scripts/utils.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const log = (...args: any[]) => {
   if (__DEBUG__) {
-    console.log('[DEBUG] ', ...args);
+    console.log('[DEBUG][refined-whatsapp] ', ...args);
   }
 };
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,3 +1,0 @@
-export const SIDEBAR_CONTROLS_ID = `side`;
-
-export const SIDEBAR_CONTROLS_SETTINGS_MENU_BUTTON = `div[title="Menu"]`;

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,0 +1,3 @@
+export const SIDEBAR_CONTROLS_ID = `side`;
+
+export const SIDEBAR_CONTROLS_SETTINGS_MENU_BUTTON = `div[title="Menu"]`;

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,18 +1,19 @@
 import { get, set } from './sync';
 import { log } from '@src/content-scripts/utils';
+import { ThemeType, ThemesList } from '@src/theme/themes';
 
 export * as storageSync from './sync';
 
-export const getPreferredTheme = async (defaultTheme?: string) => {
+export const getPreferredTheme = async (defaultTheme?: string): Promise<ThemeType> => {
   const { preferredTheme } = await get<{
     preferredTheme?: string;
   }>(['preferredTheme']);
   log('received preferred theme', { preferredTheme });
 
-  if (typeof preferredTheme === 'undefined') {
-    return defaultTheme;
+  if (typeof preferredTheme === 'undefined' || !ThemesList.includes(preferredTheme as ThemeType)) {
+    return defaultTheme as ThemeType;
   }
-  return preferredTheme;
+  return preferredTheme as ThemeType;
 };
 
 export const setPreferredTheme = async (theme: string) => {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,9 +1,10 @@
 import { createSwitcher } from './switcher';
-import { SIDEBAR_CONTROLS_ID } from '@src/selectors';
+
+import { getSidebarControls } from '@src/content-scripts/selectors';
 
 export const setupThemes = () => {
   const poller = setInterval(() => {
-    const sidebarControls = document.getElementById(SIDEBAR_CONTROLS_ID) as HTMLDivElement;
+    const sidebarControls = getSidebarControls();
 
     if (sidebarControls) {
       clearInterval(poller);

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -5,6 +5,8 @@ import { getPreferredTheme, setPreferredTheme } from '@src/storage';
 const internalStyleOverride = document.createElement('style');
 internalStyleOverride.id = 'refined-whatsapp--internal-style';
 
+const THEME_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5H16c2.76 0 5-2.24 5-5 0-4.42-4.03-8-9-8zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 9 6.5 9 8 9.67 8 10.5 7.33 12 6.5 12zm3-4C8.67 8 8 7.33 8 6.5S8.67 5 9.5 5s1.5.67 1.5 1.5S10.33 8 9.5 8zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 5 14.5 5s1.5.67 1.5 1.5S15.33 8 14.5 8zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 9 17.5 9s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>`;
+
 // module context variables :(
 let appended = false;
 let currentTheme = ThemeType.WhatsappWeb;
@@ -30,4 +32,28 @@ export const setInitialTheme = async () => {
   if (theme !== currentTheme) {
     toggleTheme();
   }
+};
+
+export const setupThemes = () => {
+  const poller = setInterval(() => {
+    const controlList = document.getElementById('side') as HTMLDivElement;
+
+    if (controlList) {
+      clearInterval(poller);
+
+      const themeBtn = document.createElement('span');
+      themeBtn.setAttribute('role', 'button');
+      themeBtn.innerHTML = THEME_ICON;
+      themeBtn.style.color = 'var(--icon)';
+      themeBtn.style.marginLeft = '12px';
+      themeBtn.addEventListener('click', () => {
+        toggleTheme();
+      });
+
+      controlList.children[0].appendChild(themeBtn);
+    }
+  }, 500);
+
+  // override default dark mode with extension's
+  document.body.classList.remove('dark');
 };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,59 +1,13 @@
-import { log } from '../content-scripts/utils';
-import { ThemeType, ThemeStyles } from './themes';
-import { getPreferredTheme, setPreferredTheme } from '@src/storage';
-
-const internalStyleOverride = document.createElement('style');
-internalStyleOverride.id = 'refined-whatsapp--internal-style';
-
-const THEME_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5H16c2.76 0 5-2.24 5-5 0-4.42-4.03-8-9-8zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 9 6.5 9 8 9.67 8 10.5 7.33 12 6.5 12zm3-4C8.67 8 8 7.33 8 6.5S8.67 5 9.5 5s1.5.67 1.5 1.5S10.33 8 9.5 8zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 5 14.5 5s1.5.67 1.5 1.5S15.33 8 14.5 8zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 9 17.5 9s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>`;
-
-// module context variables :(
-let appended = false;
-let currentTheme = ThemeType.WhatsappWeb;
-
-export const toggleTheme = () => {
-  const to = currentTheme === ThemeType.WhatsappWeb ? ThemeType.RefinedDark : ThemeType.WhatsappWeb;
-  log({ setThemeTo: to });
-
-  if (appended === false) {
-    document.head.append(internalStyleOverride);
-    appended = true;
-  }
-
-  if (ThemeStyles.has(to)) {
-    internalStyleOverride.innerText = ThemeStyles.get(to) as string;
-    currentTheme = to;
-    setPreferredTheme(to);
-  }
-};
-
-export const setInitialTheme = async () => {
-  const theme = await getPreferredTheme(currentTheme);
-  if (theme !== currentTheme) {
-    toggleTheme();
-  }
-};
+import { createSwitcher } from './switcher';
+import { SIDEBAR_CONTROLS_ID } from '@src/selectors';
 
 export const setupThemes = () => {
   const poller = setInterval(() => {
-    const controlList = document.getElementById('side') as HTMLDivElement;
+    const sidebarControls = document.getElementById(SIDEBAR_CONTROLS_ID) as HTMLDivElement;
 
-    if (controlList) {
+    if (sidebarControls) {
       clearInterval(poller);
-
-      const themeBtn = document.createElement('span');
-      themeBtn.setAttribute('role', 'button');
-      themeBtn.innerHTML = THEME_ICON;
-      themeBtn.style.color = 'var(--icon)';
-      themeBtn.style.marginLeft = '12px';
-      themeBtn.addEventListener('click', () => {
-        toggleTheme();
-      });
-
-      controlList.children[0].appendChild(themeBtn);
+      createSwitcher({ sidebarControls });
     }
   }, 500);
-
-  // override default dark mode with extension's
-  document.body.classList.remove('dark');
 };

--- a/src/theme/switcher.ts
+++ b/src/theme/switcher.ts
@@ -24,12 +24,12 @@ const createThemeControls = async () => {
 
   const setTheme = (theme: ThemeType) => {
     if (currentTheme === theme) {
+      currentThemeIndex = ThemesList.indexOf(currentTheme);
       log('🎨 :no change');
       return;
     }
 
-    log(`🎨 : ${currentTheme || 'none'} → ${theme}`);
-    currentThemeIndex = ThemesList.indexOf(currentTheme);
+    log(`🎨 : changed "${currentTheme || 'none'}" → "${theme}"`);
     appendStyleContainerIfMissing();
 
     // override theme if required
@@ -45,6 +45,7 @@ const createThemeControls = async () => {
     }
     // finally set theme
     currentTheme = theme;
+    currentThemeIndex = ThemesList.indexOf(currentTheme);
     setPreferredTheme(theme);
   };
 

--- a/src/theme/switcher.ts
+++ b/src/theme/switcher.ts
@@ -1,0 +1,82 @@
+import { SIDEBAR_CONTROLS_SETTINGS_MENU_BUTTON } from '@src/selectors';
+import { ThemeType, ThemeStyles, ThemesList } from '@src/theme/themes';
+import { getPreferredTheme, setPreferredTheme } from '@src/storage';
+import { log } from '@src/content-scripts/utils';
+
+const THEME_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5H16c2.76 0 5-2.24 5-5 0-4.42-4.03-8-9-8zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 9 6.5 9 8 9.67 8 10.5 7.33 12 6.5 12zm3-4C8.67 8 8 7.33 8 6.5S8.67 5 9.5 5s1.5.67 1.5 1.5S10.33 8 9.5 8zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 5 14.5 5s1.5.67 1.5 1.5S15.33 8 14.5 8zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 9 17.5 9s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>`;
+
+const createThemeControls = async () => {
+  const internalStyleOverride = document.createElement('style');
+  internalStyleOverride.id = 'refined-whatsapp--internal-style';
+
+  // state
+  let appended = false;
+  let currentTheme: ThemeType;
+  let currentThemeIndex: number;
+  const lastIndex = ThemesList.length - 1;
+
+  const appendStyleContainerIfMissing = () => {
+    if (!appended || document.getElementById(internalStyleOverride.id) === null) {
+      document.head.append(internalStyleOverride);
+      appended = true;
+    }
+  };
+
+  const setTheme = (theme: ThemeType) => {
+    if (currentTheme === theme) {
+      log('🎨 :no change');
+      return;
+    }
+
+    log(`🎨 : ${currentTheme || 'none'} → ${theme}`);
+    currentThemeIndex = ThemesList.indexOf(currentTheme);
+    appendStyleContainerIfMissing();
+
+    // override theme if required
+    if (theme === ThemeType.WhatsappWebDark && !document.body.classList.contains('dark')) {
+      document.body.classList.add('dark');
+    } else {
+      document.body.classList.remove('dark');
+    }
+
+    const themeStyles = ThemeStyles.get(theme);
+    if (typeof themeStyles === 'string') {
+      internalStyleOverride.innerText = themeStyles;
+    }
+    // finally set theme
+    currentTheme = theme;
+    setPreferredTheme(theme);
+  };
+
+  const cycleThemes = () => {
+    const nextThemeIndex = currentThemeIndex === lastIndex ? 0 : currentThemeIndex + 1;
+    setTheme(ThemesList[nextThemeIndex]);
+  };
+
+  const preferredTheme = await getPreferredTheme(ThemeType.RefinedDark);
+  setTheme(preferredTheme);
+
+  return {
+    cycleThemes,
+    setTheme,
+  };
+};
+
+export const createSwitcher = async ({ sidebarControls }: { sidebarControls: HTMLDivElement }) => {
+  const menuButton = sidebarControls.querySelector(SIDEBAR_CONTROLS_SETTINGS_MENU_BUTTON) as HTMLDivElement;
+  const menuButtonItem = menuButton.parentElement as HTMLDivElement;
+  const controlsList = menuButtonItem.parentElement as HTMLDivElement;
+
+  const themeBtn = document.createElement('span');
+  themeBtn.setAttribute('role', 'button');
+  themeBtn.setAttribute('title', 'Cycle themes');
+
+  themeBtn.innerHTML = THEME_ICON;
+  themeBtn.style.color = 'var(--icon)';
+  themeBtn.style.marginLeft = '12px';
+
+  const themeControls = await createThemeControls();
+  themeBtn.addEventListener('click', themeControls.cycleThemes);
+
+  controlsList.appendChild(themeBtn);
+};

--- a/src/theme/switcher.ts
+++ b/src/theme/switcher.ts
@@ -1,7 +1,7 @@
-import { SIDEBAR_CONTROLS_SETTINGS_MENU_BUTTON } from '@src/selectors';
 import { ThemeType, ThemeStyles, ThemesList } from '@src/theme/themes';
 import { getPreferredTheme, setPreferredTheme } from '@src/storage';
 import { log } from '@src/content-scripts/utils';
+import { getSidebarControlsSettingsMenuButton } from '@src/content-scripts/selectors';
 
 const THEME_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5H16c2.76 0 5-2.24 5-5 0-4.42-4.03-8-9-8zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 9 6.5 9 8 9.67 8 10.5 7.33 12 6.5 12zm3-4C8.67 8 8 7.33 8 6.5S8.67 5 9.5 5s1.5.67 1.5 1.5S10.33 8 9.5 8zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 5 14.5 5s1.5.67 1.5 1.5S15.33 8 14.5 8zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 9 17.5 9s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>`;
 
@@ -63,7 +63,7 @@ const createThemeControls = async () => {
 };
 
 export const createSwitcher = async ({ sidebarControls }: { sidebarControls: HTMLDivElement }) => {
-  const menuButton = sidebarControls.querySelector(SIDEBAR_CONTROLS_SETTINGS_MENU_BUTTON) as HTMLDivElement;
+  const menuButton = getSidebarControlsSettingsMenuButton(sidebarControls);
   const menuButtonItem = menuButton.parentElement as HTMLDivElement;
   const controlsList = menuButtonItem.parentElement as HTMLDivElement;
 

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,9 +1,15 @@
 export enum ThemeType {
-  'WhatsappWeb' = 'WhatsappWeb',
   'RefinedDark' = 'RefinedDark',
+  'WhatsappWebDark' = 'WhatsappWebDark',
+  'WhatsappWeb' = 'WhatsappWeb',
 }
 
-export const ThemeStyles = new Map<ThemeType, string>([[ThemeType.WhatsappWeb, '']]);
+export const ThemesList = [ThemeType.RefinedDark, ThemeType.WhatsappWeb, ThemeType.WhatsappWebDark];
+
+export const ThemeStyles = new Map<ThemeType, string>([
+  [ThemeType.WhatsappWeb, ''],
+  [ThemeType.WhatsappWebDark, ''],
+]);
 
 ThemeStyles.set(
   ThemeType.RefinedDark,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "moduleResolution": "node",
     "declaration": false,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["src/*"],
+      "@selectors": ["src/selectors"]
     },
     "types": ["chrome"]
   },


### PR DESCRIPTION
Instead of just toggling between WhatsApp Light & Refined Dark themes, this PR adds the functionality to cycle through the different themes. The button will cycle through the following themes:

- Refined Dark
- WhatsApp Dark
- WhatsApp Light